### PR TITLE
FIX - Make select_rows compatible with AR 4.1

### DIFF
--- a/lib/active_record/connection_adapters/redshift/database_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/database_statements.rb
@@ -46,7 +46,7 @@ module ActiveRecord
 
         # Executes a SELECT query and returns an array of rows. Each row is an
         # array of field values.
-        def select_rows(sql, name = nil)
+        def select_rows(sql, name = nil, bind = [])
           select_raw(sql, name).last
         end
 


### PR DESCRIPTION
This was needed to get a schema load to work the first
time a schema is created.