### PR TITLE
Commented out type_for_column on column.array

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -22,13 +22,14 @@ module ActiveRecord
           end
         end
 
-        def type_for_column(column)
-          if column.array
-            @conn.lookup_cast_type("#{column.sql_type}[]")
-          else
-            super
-          end
-        end
+        # TODO check if this is needed
+        #def type_for_column(column)
+          #if column.array
+            #@conn.lookup_cast_type("#{column.sql_type}[]")
+          #else
+            #super
+          #end
+        #end
       end
 
       module SchemaStatements


### PR DESCRIPTION
Added originally to kushkella's repo https://github.com/kushkella/activerecord4-redshift-adapter/pull/1

This method is no longer used but is attempted to be called and there is no array to any "column"