### PR TITLE
Fix: PG::SyntaxError: Replace 'DISCARD ALL' query to similer operations.

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -247,7 +247,6 @@ module ActiveRecord
         session_auth = 'DEFAULT'
         @connection.query 'RESET ALL'
         @statements.clear if @statements
-        @connection.query 'CLOSE ALL'
         configure_connection
       end
 

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -246,7 +246,7 @@ module ActiveRecord
         end
         session_auth = 'DEFAULT'
         @connection.query 'RESET ALL'
-        dealloc 'ALL'
+        @statements.clear if @statements
         @connection.query 'CLOSE ALL'
         configure_connection
       end

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -244,7 +244,10 @@ module ActiveRecord
         unless @connection.transaction_status == ::PG::PQTRANS_IDLE
           @connection.query 'ROLLBACK'
         end
-        @connection.query 'DISCARD ALL'
+        session_auth = 'DEFAULT'
+        @connection.query 'RESET ALL'
+        dealloc 'ALL'
+        @connection.query 'CLOSE ALL'
         configure_connection
       end
 


### PR DESCRIPTION
`DISCARD` was implemented on PostgreSQL since v8.3
However, Redshift is based on PostgreSQL 8.0.2

References
- [PostgreSQL DISCARD](https://www.postgresql.org/docs/current/static/sql-discard.html)
- [Amazon Redshift and PostgreSQL](http://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html)

Fix: #25
