### PR TITLE
sortkey, distkey options for columns

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -11,7 +11,10 @@ module ActiveRecord
         end
       end
 
-      class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
+      class ColumnDefinition < Struct.new(*ActiveRecord::ConnectionAdapters::ColumnDefinition.members, :sortkey, :distkey)
+        def primary_key?
+          primary_key || type.to_sym == :primary_key
+        end
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
@@ -50,6 +53,13 @@ module ActiveRecord
           options[:default] = options.fetch(:default, 'uuid_generate_v4()')
           options[:primary_key] = true
           column name, type, options
+        end
+
+        def new_column_definition(name, type, options) # :nodoc:
+          column = super
+          column.sortkey = options[:sortkey]
+          column.distkey = options[:distkey]
+          column
         end
 
         private

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -14,20 +14,24 @@ module ActiveRecord
         end
 
         def add_column_options!(sql, options)
-          column = options.fetch(:column) { return super }
-          if column.type == :uuid && options[:default] =~ /\(\)/
-            sql << " DEFAULT #{options[:default]}"
-          else
-            super
+          puts options.inspect
+
+          if options[:sortkey]
+            sql << " SORTKEY"
           end
+
+          if options[:distkey]
+            sql << " DISTKEY"
+          end
+
+          super
         end
 
-        def type_for_column(column)
-          if column.array
-            @conn.lookup_cast_type("#{column.sql_type}[]")
-          else
-            super
-          end
+        def column_options(o)
+          column_options = super
+          column_options[:sortkey] = o.sortkey
+          column_options[:distkey] = o.distkey
+          column_options
         end
       end
 


### PR DESCRIPTION
This adds `sortkey`, `distkey` options for columns in tables newly created.

```ruby
create_table :products, id: false do |t|
  t.string :product_id, limit: 256, sortkey: true, distkey: true
end
# => CREATE TABLE "products" ("product_id" varchar(256) SORTKEY DISTKEY)
```