### PR TITLE
Backward-compatible fix for NoMethodError

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         end
 
         def type_for_column(column)
-          if column.array
+          if column.respond_to?(:array) && column.array
             @conn.lookup_cast_type("#{column.sql_type}[]")
           else
             super


### PR DESCRIPTION
This is a fix for https://github.com/aamine/activerecord4-redshift-adapter/issues/31

This also allows migrations to succeed, whether or not you already have an `schema_migrations` table.